### PR TITLE
Fix reproducibility issues in ASR and ESM2 workflows

### DIFF
--- a/ASR/ASR_notebook.ipynb
+++ b/ASR/ASR_notebook.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "input_fasta = Path(input_fasta)\n",
     "outgroup_path = Path(outgroup_path)\n",
-    "run_folder = Path(\"ADA1_ASR/outputs\")\n",
+    "run_folder = input_fasta.parent.parent / \"outputs\"\n",
     "run_folder.mkdir(exist_ok=True, parents=True)"
    ]
   },

--- a/ESM2_scoring/README.md
+++ b/ESM2_scoring/README.md
@@ -54,12 +54,12 @@ python esm2_pppl_calculator.py --input inputs/ADA1_native_and_anc.fasta --output
 python esm2_pppl_calculator.py --input inputs/consensus_ADA1_ancestors.fa --output outputs/consensus_ADA1_ancestors_esm2_scores_650M.csv --model esm2_t33_650M_UR50D
 python esm2_pppl_calculator.py --input inputs/consensus_isomaltase_ancestors.fa --output outputs/consensus_isomaltase_ancestors_esm2_scores_650M.csv --model esm2_t33_650M_UR50D
 
-python esm2_pppl_calculator.py --input inputs/isomaltase_native_and_anc.fasta --output outputs/isomaltase_all_esm2_scores_8M --model esm2_t6_8M_UR50D
-python esm2_pppl_calculator.py --input inputs/isomaltase_native_and_anc.fasta --output outputs/isomaltase_all_esm2_scores_35M --model esm2_t12_35M_UR50D
-python esm2_pppl_calculator.py --input inputs/isomaltase_native_and_anc.fasta --output outputs/isomaltase_all_esm2_scores_150M --model esm2_t30_150M_UR50D
-python esm2_pppl_calculator.py --input inputs/isomaltase_native_and_anc.fasta --output outputs/isomaltase_all_esm2_scores_3B --model esm2_t36_3B_UR50D
-python esm2_pppl_calculator.py --input inputs/isomaltase_native_and_anc.fasta --output outputs/isomaltase_all_esm2_scores_650M --model esm2_t33_650M_UR50D
+python esm2_pppl_calculator.py --input inputs/isomaltase_native_and_anc.fasta --output outputs/isomaltase_all_esm2_scores_8M.csv --model esm2_t6_8M_UR50D
+python esm2_pppl_calculator.py --input inputs/isomaltase_native_and_anc.fasta --output outputs/isomaltase_all_esm2_scores_35M.csv --model esm2_t12_35M_UR50D
+python esm2_pppl_calculator.py --input inputs/isomaltase_native_and_anc.fasta --output outputs/isomaltase_all_esm2_scores_150M.csv --model esm2_t30_150M_UR50D
+python esm2_pppl_calculator.py --input inputs/isomaltase_native_and_anc.fasta --output outputs/isomaltase_all_esm2_scores_3B.csv --model esm2_t36_3B_UR50D
+python esm2_pppl_calculator.py --input inputs/isomaltase_native_and_anc.fasta --output outputs/isomaltase_all_esm2_scores_650M.csv --model esm2_t33_650M_UR50D
 
 python esm2_pppl_calculator.py --input inputs/ADA1_remaining.fasta --output outputs/ADA1_remaining_esm2_scores_650M.csv --model esm2_t33_650M_UR50D
-python esm2_pppl_calculator.py --input inputs/isomaltase_remaining.fasta --output isomaltase_remaining_esm2_scores_650M.csv --model esm2_t33_650M_UR50D
+python esm2_pppl_calculator.py --input inputs/isomaltase_remaining.fasta --output outputs/isomaltase_remaining_esm2_scores_650M.csv --model esm2_t33_650M_UR50D
 ```

--- a/env.yml
+++ b/env.yml
@@ -14,6 +14,7 @@ dependencies:
       - plotly==5.24.1
       - arcadia-pycolor==0.5.1
       - matplotlib==3.9.2
+      - seaborn==0.13.2
       - pandas==2.2.3
       - scikit-posthocs==0.11.4
 


### PR DESCRIPTION
Fixes surfaced by the reproducibility audit. Three independent issues, each verified against the code and committed data:

### 1. ASR notebook hardcoded `run_folder` (real bug)
`ASR/ASR_notebook.ipynb` hardcoded `run_folder = Path("ADA1_ASR/outputs")`, but only `input_fasta` and `outgroup_path` are papermill parameters. Following `ASR/README.md`'s isomaltase command would silently write all outputs into `ADA1_ASR/outputs/` (overwriting ADA1 results) instead of `Isomaltase_ASR/outputs/`. Now derived as `input_fasta.parent.parent / "outputs"`, which yields the correct directory for both analyses.

### 2. ESM2 reproduce commands had broken output paths
In `ESM2_scoring/README.md`:
- Lines 57–61 (isomaltase) omitted the `.csv` extension. The script does `df.to_csv(args.output)` verbatim (no auto-extension), and `index.ipynb` reads these with `.csv` — so the documented commands produced files the notebook can't find.
- The `isomaltase_remaining` command was missing the `outputs/` prefix (the lone outlier in the block).

Both now match what `index.ipynb` reads and the committed output filenames. Affects re-running the upstream ESM2 step only; the main render uses the committed CSVs.

### 3. `seaborn` missing from `env.yml`
Imported in `src/analysis/data_processing.py` but not a guaranteed transitive dependency. Pinned to `0.13.2` to match the version installed in the working conda environment.